### PR TITLE
Fixed a problem when one of the parent directories contain a dot.

### DIFF
--- a/de4dot.code/ObfuscatedFile.cs
+++ b/de4dot.code/ObfuscatedFile.cs
@@ -151,17 +151,8 @@ namespace de4dot.code {
 		}
 
 		string GetDefaultNewFilename() {
-			int dotIndex = options.Filename.LastIndexOf('.');
-			string noExt, ext;
-			if (dotIndex != -1) {
-				noExt = options.Filename.Substring(0, dotIndex);
-				ext = options.Filename.Substring(dotIndex);
-			}
-			else {
-				noExt = options.Filename;
-				ext = "";
-			}
-			return noExt + "-cleaned" + ext;
+			string newFilename = Path.GetFileNameWithoutExtension(options.Filename) + "-cleaned" + Path.GetExtension(options.Filename);
+			return Path.Combine(Path.GetDirectoryName(options.Filename), newFilename);
 		}
 
 		public void Load(IList<IDeobfuscator> deobfuscators) {


### PR DESCRIPTION
This is a small fix for a bug in de4dot, when one of the directories in the path to the input file contains a period (.) character, thus de4dot cuts the path at the wrong place.