### PR TITLE
CryptoObfuscator: Detect if decrypter should skip before reading flag or vice versa

### DIFF
--- a/de4dot.code/deobfuscators/CryptoObfuscator/ResourceDecrypter.cs
+++ b/de4dot.code/deobfuscators/CryptoObfuscator/ResourceDecrypter.cs
@@ -183,6 +183,7 @@ namespace de4dot.code.deobfuscators.CryptoObfuscator {
 		static bool CheckFlipBits(MethodDef method, out int index) {
 			int nots = 0, i;
 			var instrs = method.Body.Instructions;
+			index = -1;
 			for (i = 0; i < instrs.Count - 1; i++) {
 				var ldloc = instrs[i];
 				if (!ldloc.IsLdloc())
@@ -190,11 +191,11 @@ namespace de4dot.code.deobfuscators.CryptoObfuscator {
 				var local = ldloc.GetLocal(method.Body.Variables);
 				if (local == null || local.Type.GetElementType().GetPrimitiveSize() < 0)
 					continue;
-
-				if (instrs[i + 1].OpCode.Code == Code.Not)
+				if (instrs[i + 1].OpCode.Code == Code.Not) {
 					nots++;
+					index = i + 1;
+				}
 			}
-			index = i;
 			return (nots & 1) == 1;
 		}
 


### PR DESCRIPTION
Seems like some versions of CryptoObfuscator skip the bytes before reading the actual flag instead of the behaviour expected by de4dot currently.

```
	IL_0000: ldarg.1
	IL_0001: stloc.0
	IL_0002: ldsfld    class [mscorlib]System.IO.MemoryStream A.ce092df84f191ecd88cbb0010b0dc244a::c1332bc575f807cafdd81bf4e82c44ce6
	IL_0007: stloc.1
	IL_0008: ldc.i4.1
	IL_0009: stloc.2
	IL_000A: br.s      IL_0019
	// loop start (head: IL_0019)
		IL_000C: ldarg.1
		IL_000D: callvirt  instance int32 [mscorlib]System.IO.Stream::ReadByte()
		IL_0012: dup
		IL_0013: pop
		IL_0014: pop
		IL_0015: ldloc.2
		IL_0016: ldc.i4.1
		IL_0017: add
		IL_0018: stloc.2

		IL_0019: ldloc.2
		IL_001A: ldc.i4.4
		IL_001B: blt.s     IL_000C
	// end loop
	// loop start (head: IL_001D)
		IL_001D: ldc.i4.2
		IL_001E: switch    (IL_001D)
	// end loop

	IL_0027: ldc.i4.1
	IL_0028: brtrue.s  IL_0030

	IL_002A: ldtoken   method uint8[] A.c741f255b5f4321922aee8204a49edb9e::c3c1e8cb1d000e8b8232ad3c58c751a1d(int64, class [mscorlib]System.IO.Stream)
	IL_002F: pop

	IL_0030: ldarg.1
	IL_0031: callvirt  instance int32 [mscorlib]System.IO.Stream::ReadByte()
	IL_0036: dup
	IL_0037: pop
	IL_0038: conv.u2
	IL_0039: stloc.3
	IL_003A: ldloc.3
	IL_003B: not
	IL_003C: conv.u2
	IL_003D: stloc.3
	IL_003E: ldloc.3
	IL_003F: ldc.i4.2
	IL_0040: and
	IL_0041: brfalse   IL_0251
```