### PR TITLE
Added option --only-cflow-deob for only deobfuscating control flow

### DIFF
--- a/de4dot.cui/CommandLineParser.cs
+++ b/de4dot.cui/CommandLineParser.cs
@@ -157,6 +157,21 @@ namespace de4dot.cui {
 			miscOptions.Add(new NoArgOption(null, "no-cflow-deob", "No control flow deobfuscation (NOT recommended)", () => {
 				filesOptions.ControlFlowDeobfuscation = false;
 			}));
+			miscOptions.Add(new NoArgOption(null, "only-cflow-deob", "Only control flow deobfuscation", () => {
+				filesOptions.ControlFlowDeobfuscation = true;
+				// --strtyp none
+				defaultStringDecrypterType = DecrypterType.None;
+				// --keep-types
+				filesOptions.KeepObfuscatorTypes = true;
+				// --preserve-tokens
+				filesOptions.MetaDataFlags |= MetaDataFlags.PreserveRids |
+						MetaDataFlags.PreserveUSOffsets |
+						MetaDataFlags.PreserveBlobOffsets |
+						MetaDataFlags.PreserveExtraSignatureData;
+				// --dont-rename
+				filesOptions.RenameSymbols = false;
+				filesOptions.RenamerFlags = 0;
+			}));
 			miscOptions.Add(new NoArgOption(null, "load-new-process", "Load executed assemblies into a new process", () => {
 				filesOptions.AssemblyClientFactory = new NewProcessAssemblyClientFactory();
 			}));


### PR DESCRIPTION
Just a shortcut option that should be equivalent to: `de4dot --keep-types --preserve-tokens --dont-rename Program.exe --strtyp none`