### PR TITLE
Added support for Eazfuscator.NET 5.1

### DIFF
--- a/de4dot.code/deobfuscators/Eazfuscator_NET/DecrypterType.cs
+++ b/de4dot.code/deobfuscators/Eazfuscator_NET/DecrypterType.cs
@@ -35,6 +35,7 @@ namespace de4dot.code.deobfuscators.Eazfuscator_NET {
 		int i1, i2, i3;
 		int m1_i1, m2_i1, m2_i2, m3_i1;
 		MethodDef[] efConstMethods;
+		List<int> shiftConsts;
 
 		public MethodDef Int64Method {
 			get { return int64Method; }
@@ -52,6 +53,16 @@ namespace de4dot.code.deobfuscators.Eazfuscator_NET {
 
 		public bool Detected {
 			get { return type != null; }
+		}
+
+		public List<int> ShiftConsts {
+			get { return shiftConsts; }
+			set {
+				if (shiftConsts == null)
+					shiftConsts = value;
+				else if (shiftConsts != value)
+					throw new ApplicationException("Found another one");
+			}
 		}
 
 		public DecrypterType(ModuleDefMD module, ISimpleDeobfuscator simpleDeobfuscator) {
@@ -337,51 +348,6 @@ namespace de4dot.code.deobfuscators.Eazfuscator_NET {
 			return BinOp1(efConstMethods[5].DeclaringType.MDToken.ToInt32(), BinOp3(BinOp2(efConstMethods[4].DeclaringType.MDToken.ToInt32(), efConstMethods[0].DeclaringType.MDToken.ToInt32()), BinOp3(efConstMethods[2].DeclaringType.MDToken.ToInt32() ^ i3, ConstMethod5())));
 		}
 
-		bool FindShiftInts(MethodDef method, out List<int> bytes) {
-			var instrs = method.Body.Instructions;
-			var constantsReader = new EfConstantsReader(method);
-			bytes = new List<int>(8);
-
-			for (int i = 0; i < instrs.Count - 4; i++) {
-				if (bytes.Count >= 8)
-					return true;
-
-				var ldloc1 = instrs[i];
-				if (ldloc1.OpCode.Code != Code.Ldloc_1)
-					continue;
-
-				var ldlocs = instrs[i + 1];
-				if (ldlocs.OpCode.Code != Code.Ldloc_S)
-					continue;
-
-				var maybe = instrs[i + 2];
-				if (maybe.OpCode.Code == Code.Conv_U1) {
-					var callvirt = instrs[i + 3];
-					if (callvirt.OpCode.Code != Code.Callvirt)
-						return false;
-
-					bytes.Add(0);
-					continue;
-				}
-				var shr = instrs[i + 3];
-				if (shr.OpCode.Code != Code.Shr)
-					return false;
-
-				var convu1 = instrs[i + 4];
-				if (convu1.OpCode.Code != Code.Conv_U1)
-					return false;
-
-				int constant;
-				int index = i + 2;
-				if (!constantsReader.GetInt32(ref index, out constant))
-					return false;
-
-				bytes.Add(constant);
-			}
-
-			return false;
-		}
-
 		public ulong GetMagic() {
 			if (type == null)
 				throw new ApplicationException("Can't calculate magic since type isn't initialized");
@@ -392,10 +358,6 @@ namespace de4dot.code.deobfuscators.Eazfuscator_NET {
 					bytes.AddRange(module.Assembly.PublicKeyToken.Data);
 				bytes.AddRange(Encoding.Unicode.GetBytes(module.Assembly.Name.String));
 			}
-
-			List<int> shiftConsts;
-			if (!FindShiftInts(int64Method, out shiftConsts))
-				throw new ApplicationException("Could not extract magic constants");
 
 			int num3 = ConstMethod1();
 			int num2 = type.MDToken.ToInt32();

--- a/de4dot.code/deobfuscators/Eazfuscator_NET/StringDecrypter.cs
+++ b/de4dot.code/deobfuscators/Eazfuscator_NET/StringDecrypter.cs
@@ -47,6 +47,7 @@ namespace de4dot.code.deobfuscators.Eazfuscator_NET {
 		EfConstantsReader stringMethodConsts;
 		bool isV32OrLater;
 		bool isV50OrLater;
+		bool isV51OrLater;
 		int? validStringDecrypterValue;
 		DynamicDynocodeIterator dynocode;
 		MethodDef realMethod;
@@ -429,11 +430,7 @@ namespace de4dot.code.deobfuscators.Eazfuscator_NET {
 				return null;
 			if (instrs[index++].OpCode.Code != Code.Ldc_I4_0)
 				return null;
-			if (instrs[index++].OpCode.Code != Code.Ceq)
-				return null;
-			if (instrs[index++].OpCode.Code != Code.Ldc_I4_0)
-				return null;
-			if (instrs[index++].OpCode.Code != Code.Ceq)
+			if (instrs[index++].OpCode.Code != Code.Cgt_Un)
 				return null;
 			var stloc = instrs[index++];
 			if (!stloc.IsStloc())
@@ -720,8 +717,8 @@ done: ;
 
 			if (index + 4 >= instrs.Count)
 				return false;
-			var ldloc = instrs[index + 3];
-			var stfld = instrs[index + 4];
+			var ldloc = instrs[index + 2];
+			var stfld = instrs[index + 3];
 			if (!ldloc.IsLdloc() || stfld.OpCode.Code != Code.Stfld)
 				return false;
 			var enumerableField = stfld.Operand as FieldDef;

--- a/de4dot.code/deobfuscators/Eazfuscator_NET/VersionDetector.cs
+++ b/de4dot.code/deobfuscators/Eazfuscator_NET/VersionDetector.cs
@@ -668,7 +668,7 @@ namespace de4dot.code.deobfuscators.Eazfuscator_NET {
 					(decryptStringMethod.Body.ExceptionHandlers.Count == 1 || decryptStringMethod.Body.ExceptionHandlers.Count == 2) &&
 					new LocalTypes(decryptStringMethod).Exactly(locals33_149) &&
 					CheckTypeFields2(fields33_149)) {
-					return "3.3.149 - 3.4";	// 3.3.149+ (but not SL or CF)
+					return "3.3.149 - 3.4"; // 3.3.149+ (but not SL or CF)
 				}
 
 				/////////////////////////////////////////////////////////////////
@@ -819,11 +819,11 @@ namespace de4dot.code.deobfuscators.Eazfuscator_NET {
 					decryptStringMethod.Body.ExceptionHandlers.Count == 1 &&
 					new LocalTypes(decryptStringMethod).All(locals50) &&
 					CheckTypeFields2(fields50)) {
-                    foreach (var inst in stringDecrypter.Method.Body.Instructions) {
-                        if (inst.OpCode.Code == Code.Cgt_Un)
-                            return "5.1";
-                    }
-                    return "5.0";
+					foreach (var inst in stringDecrypter.Method.Body.Instructions) {
+						if (inst.OpCode.Code == Code.Cgt_Un)
+							return "5.1";
+					}
+					return "5.0";
 				}
 			}
 

--- a/de4dot.code/deobfuscators/Eazfuscator_NET/VersionDetector.cs
+++ b/de4dot.code/deobfuscators/Eazfuscator_NET/VersionDetector.cs
@@ -19,6 +19,7 @@
 
 using System;
 using System.Collections.Generic;
+using dnlib.DotNet.Emit;
 using dnlib.DotNet;
 using de4dot.blocks;
 
@@ -818,7 +819,11 @@ namespace de4dot.code.deobfuscators.Eazfuscator_NET {
 					decryptStringMethod.Body.ExceptionHandlers.Count == 1 &&
 					new LocalTypes(decryptStringMethod).All(locals50) &&
 					CheckTypeFields2(fields50)) {
-					return "5.0";
+                    foreach (var inst in stringDecrypter.Method.Body.Instructions) {
+                        if (inst.OpCode.Code == Code.Cgt_Un)
+                            return "5.1";
+                    }
+                    return "5.0";
 				}
 			}
 


### PR DESCRIPTION
* Eazfuscator 5.1 uses slightly different opcodes in string decryption method. These are addressed in methods `EmulateDynocode` and `GetFlagsLocal`.
* During my testings I encountered a binary whose `magic1` was calculated using this order:
```c#
	list.Add((byte)(num2 >> 16));
	list.Add((byte)(num3 >> 24));
	list.Add((byte)(num2 >> 24));
	list.Add((byte)(num3 >> 8));
	list.Add((byte)num2);
	list.Add((byte)(num3 >> 16));
	list.Add((byte)(num2 >> 8));
	list.Add((byte)num3);
```
rather than the traditional:
```c#
	list.Add((byte)(num2 >> 24));
	list.Add((byte)(num3 >> 16));
	list.Add((byte)(num2 >> 8));
	list.Add((byte)num3);
	list.Add((byte)(num2 >> 16));
	list.Add((byte)(num3 >> 8));
	list.Add((byte)num2);
	list.Add((byte)(num3 >> 24));
```
* This caused failures for deobfuscating the binary. I'm not too sure but it looks like the ordering was not dependent on the version of the obfuscator used so, added code to get shift numbers from the assembly.
* Version detection strategy for 5.1 may be flawed, but I haven't got any problems with my testings on 5.0 and 5.1. I would like to hear feedback about this as well. 