### PR TITLE
Fix for latest .Net Reactor

### DIFF
--- a/de4dot.blocks/cflow/Int32Value.cs
+++ b/de4dot.blocks/cflow/Int32Value.cs
@@ -333,13 +333,13 @@ namespace de4dot.blocks.cflow {
 
 		public static Real8Value Conv_R_Un(Int32Value a) {
 			if (a.AllBitsValid())
-				return new Real8Value((float)(uint)a.Value);
+				return new Real8Value((double)(uint)a.Value);
 			return Real8Value.CreateUnknown();
 		}
 
 		public static Real8Value Conv_R4(Int32Value a) {
 			if (a.AllBitsValid())
-				return new Real8Value((float)(int)a.Value);
+				return new Real8Value((double)(int)a.Value);
 			return Real8Value.CreateUnknown();
 		}
 

--- a/de4dot.code/deobfuscators/dotNET_Reactor/v4/EncryptedResource.cs
+++ b/de4dot.code/deobfuscators/dotNET_Reactor/v4/EncryptedResource.cs
@@ -104,10 +104,10 @@ namespace de4dot.code.deobfuscators.dotNET_Reactor.v4 {
 			if (additionalTypes == null)
 				additionalTypes = new string[0];
 			var localTypes = new LocalTypes(method);
-			if (DecrypterV1.CouldBeResourceDecrypter(method, localTypes, additionalTypes))
-				return DnrDecrypterType.V1;
-			else if (DecrypterV2.CouldBeResourceDecrypter(method, localTypes, additionalTypes))
+			if (DecrypterV2.CouldBeResourceDecrypter(method, localTypes, additionalTypes))
 				return DnrDecrypterType.V2;
+			else if (DecrypterV1.CouldBeResourceDecrypter(method, localTypes, additionalTypes))
+				return DnrDecrypterType.V1;
 			return DnrDecrypterType.Unknown;
 		}
 


### PR DESCRIPTION
- Fake match of DecrypterV1 signature instead of V2
- instructionEmulator confusion on Int32 to Real8 convertion