### PR TITLE
Addition of automatic string obfusicator token detection --strtok-auto

### DIFF
--- a/de4dot.code/ObfuscatedFile.cs
+++ b/de4dot.code/ObfuscatedFile.cs
@@ -90,10 +90,9 @@ namespace de4dot.code {
 			public bool ControlFlowDeobfuscation { get; set; }
 			public bool KeepObfuscatorTypes { get; set; }
 			public bool PreserveTokens { get; set; }
-			public MetaDataFlags MetaDataFlags { get; set; }
-			public RenamerFlags RenamerFlags { get; set; }
-            //Addition - Roland.H
             public bool AutoDetectStringObfusicators { get; set; }
+            public MetaDataFlags MetaDataFlags { get; set; }
+			public RenamerFlags RenamerFlags { get; set; }
 
 			public Options() {
 				StringDecrypterType = DecrypterType.Default;
@@ -465,26 +464,23 @@ namespace de4dot.code {
             if (options.AutoDetectStringObfusicators)
             {
                 Logger.Log(LoggerEvent.Info, "Scanning for static string obfusicator methods...");
-                foreach (TypeDef classDef in module.GetTypes())
-                {
+                foreach (TypeDef classDef in module.GetTypes()) { 
                     foreach (MethodDef method in classDef.Methods)
-                    {
-                        if (IsStringObfusciator(method)) tokens.Add(method.MDToken.ToInt32());
+                        if (IsStaticStringObfusciator(method)) tokens.Add(method.MDToken.ToInt32());
                     }
-                }
             }
 
 			return tokens;
 		}
 
-        bool IsStringObfusciator(MethodDef method)
+        /* Detects static string obfusicators that an integer and return a string*/
+        bool IsStaticStringObfusciator(MethodDef method)
         {
             if (method == null) return false;
             if (method.Body == null) return false;
             if (method.Body.Instructions == null) return false;
             if (!method.IsStatic) return false;
             if (!DotNetUtils.IsMethod(method, "System.String", "(System.Int32)")) return false;
-            if (method.Name == ".ctor" || method.Name == ".cctor") return false;
 
             Logger.Log(LoggerEvent.Info, "Found: " + method.FullName.Replace(" System.String","") + " Token: 0x" + method.MDToken.ToInt32().ToString("X"));
 

--- a/de4dot.code/ObfuscatedFile.cs
+++ b/de4dot.code/ObfuscatedFile.cs
@@ -92,6 +92,8 @@ namespace de4dot.code {
 			public bool PreserveTokens { get; set; }
 			public MetaDataFlags MetaDataFlags { get; set; }
 			public RenamerFlags RenamerFlags { get; set; }
+            //Addition - Roland.H
+            public bool AutoDetectStringObfusicators { get; set; }
 
 			public Options() {
 				StringDecrypterType = DecrypterType.Default;
@@ -139,7 +141,7 @@ namespace de4dot.code {
 		public ObfuscatedFile(Options options, ModuleContext moduleContext, IAssemblyClientFactory assemblyClientFactory) {
 			this.assemblyClientFactory = assemblyClientFactory;
 			this.options = options;
-			userStringDecrypterMethods = options.StringDecrypterMethods.Count > 0;
+			userStringDecrypterMethods = (options.StringDecrypterMethods.Count > 0) || options.AutoDetectStringObfusicators;
 			options.Filename = Utils.GetFullPath(options.Filename);
 			assemblyModule = new AssemblyModule(options.Filename, moduleContext);
 
@@ -459,8 +461,36 @@ namespace de4dot.code {
 					tokens.AddRange(FindMethodTokens(val));
 			}
 
+            //Auto detect static string obfusicators that can be deobfusicated by a delegate
+            if (options.AutoDetectStringObfusicators)
+            {
+                Logger.Log(LoggerEvent.Info, "Scanning for static string obfusicator methods...");
+                foreach (TypeDef classDef in module.GetTypes())
+                {
+                    foreach (MethodDef method in classDef.Methods)
+                    {
+                        if (IsStringObfusciator(method)) tokens.Add(method.MDToken.ToInt32());
+                    }
+                }
+            }
+
 			return tokens;
 		}
+
+        bool IsStringObfusciator(MethodDef method)
+        {
+            if (method == null) return false;
+            if (method.Body == null) return false;
+            if (method.Body.Instructions == null) return false;
+            if (!method.IsStatic) return false;
+            if (!DotNetUtils.IsMethod(method, "System.String", "(System.Int32)")) return false;
+            if (method.Name == ".ctor" || method.Name == ".cctor") return false;
+
+            Logger.Log(LoggerEvent.Info, "Found: " + method.FullName.Replace(" System.String","") + " Token: 0x" + method.MDToken.ToInt32().ToString("X"));
+
+            return true;
+
+        }
 
 		IEnumerable<int> FindMethodTokens(string methodDesc) {
 			var tokens = new List<int>();

--- a/de4dot.cui/CommandLineParser.cs
+++ b/de4dot.cui/CommandLineParser.cs
@@ -257,6 +257,8 @@ namespace de4dot.cui {
 				if (defaultStringDecrypterType != null)
 					newFileOptions.StringDecrypterType = defaultStringDecrypterType.Value;
 				newFileOptions.StringDecrypterMethods.AddRange(defaultStringDecrypterMethods);
+                //Addition - rolandh
+                newFileOptions.AutoDetectStringObfusicators = false;
 			});
 			fileOptions.Add(defaultOption);
 			fileOptions.Add(new OneArgOption("o", null, "Name of output file", "file", (val) => {
@@ -282,13 +284,19 @@ namespace de4dot.cui {
 					ExitError(string.Format("Invalid string decrypter type '{0}'", val));
 				newFileOptions.StringDecrypterType = (DecrypterType)decrypterType;
 			}));
-			fileOptions.Add(new OneArgOption(null, "strtok", "String decrypter method token or [type::][name][(args,...)]", "method", (val) => {
-				if (newFileOptions == null)
-					ExitError("Missing input file");
-				newFileOptions.StringDecrypterMethods.Add(val);
+            fileOptions.Add(new OneArgOption(null, "strtok", "String decrypter method token or [type::][name][(args,...)]", "method", (val) => {
+                if (newFileOptions == null)
+                    ExitError("Missing input file");
+                newFileOptions.StringDecrypterMethods.Add(val);
 			}));
+        
+            fileOptions.Add(new NoArgOption(null, "strtok-auto", "Auto detect static string obfusicator tokens with sig {static string methodName(int magicNumber)}", () => {
+                if (newFileOptions == null)
+                    ExitError("Missing input file");
+                newFileOptions.AutoDetectStringObfusicators = true;
+            }));
 
-			AddOptions(miscOptions);
+            AddOptions(miscOptions);
 			AddOptions(fileOptions);
 			foreach (var info in deobfuscatorInfos)
 				AddOptions(info.GetOptions());

--- a/de4dot.cui/CommandLineParser.cs
+++ b/de4dot.cui/CommandLineParser.cs
@@ -257,7 +257,6 @@ namespace de4dot.cui {
 				if (defaultStringDecrypterType != null)
 					newFileOptions.StringDecrypterType = defaultStringDecrypterType.Value;
 				newFileOptions.StringDecrypterMethods.AddRange(defaultStringDecrypterMethods);
-                //Addition - rolandh
                 newFileOptions.AutoDetectStringObfusicators = false;
 			});
 			fileOptions.Add(defaultOption);

--- a/de4dot.cui/Program.cs
+++ b/de4dot.cui/Program.cs
@@ -152,7 +152,6 @@ namespace de4dot.cui {
 				catch (InvalidOperationException) {
 				}
 			}
-            Console.ReadKey();
 			return exitCode;
 		}
 

--- a/de4dot.cui/Program.cs
+++ b/de4dot.cui/Program.cs
@@ -88,7 +88,8 @@ namespace de4dot.cui {
 				new de4dot.code.deobfuscators.SmartAssembly.DeobfuscatorInfo(),
 				new de4dot.code.deobfuscators.Spices_Net.DeobfuscatorInfo(),
 				new de4dot.code.deobfuscators.Xenocode.DeobfuscatorInfo(),
-			};
+                //new de4dot.code.deobfuscators.DynamicString.DeobfuscatorInfo(),
+            };
 			var dict = new Dictionary<string, IDeobfuscatorInfo>();
 			foreach (var d in local)
 				dict[d.Type] = d;
@@ -151,7 +152,7 @@ namespace de4dot.cui {
 				catch (InvalidOperationException) {
 				}
 			}
-
+            Console.ReadKey();
 			return exitCode;
 		}
 


### PR DESCRIPTION
Added --strtok-auto which will add all methods that have the following signature to the list of method tokens
`static string methodName(int magicNumber);`
Very useful when you have an unknown obfusciator with hundreds of static string functions often with different signatures.

I'd like to add it to the master as I found it very useful when trying to de-obfuscicate assemblies that use custom obfusicators.