### PR TITLE
Fix de4dot compilation on Ubuntu xenial (mono v4.5)

### DIFF
--- a/de4dot.cui/FilesDeobfuscator.cs
+++ b/de4dot.cui/FilesDeobfuscator.cs
@@ -177,7 +177,7 @@ namespace de4dot.cui {
 				public ModuleContext ModuleContext { get; set; }
 				public IEnumerable<IObfuscatedFile> PossibleFiles { get; set; }
 				public IEnumerable<SearchDir> SearchDirs { get; set; }
-				public Func<IList<IDeobfuscator>> CreateDeobfuscators { get; set; }
+				public de4dot.code.Func<IList<IDeobfuscator>> CreateDeobfuscators { get; set; }
 				public DecrypterType? DefaultStringDecrypterType { get; set; }
 				public List<string> DefaultStringDecrypterMethods { get; set; }
 				public IAssemblyClientFactory AssemblyClientFactory { get; set; }


### PR DESCRIPTION
xbuild /p:TargetFrameworkVersion="v4.5" de4dot.sln

/usr/lib/mono/4.5/Microsoft.CSharp.targets (CoreCompile target) ->

        FilesDeobfuscator.cs(180,12): error CS0104: `Func' is an ambiguous reference between `System.Func<TResult>' and `de4dot.code.Func<TResult>'
        FilesDeobfuscator.cs(180,12): error CS0104: `Func' is an ambiguous reference between `System.Func<TResult>' and `de4dot.code.Func<TResult>'
        FilesDeobfuscator.cs(180,12): error CS0104: `Func' is an ambiguous reference between `System.Func<TResult>' and `de4dot.code.Func<TResult>'

         1 Warning(s)
         3 Error(s)