### PR TITLE
Force PDB generation switch to force compatibility with dotPeek and others

### DIFF
--- a/de4dot.code/AssemblyModule.cs
+++ b/de4dot.code/AssemblyModule.cs
@@ -56,6 +56,11 @@ namespace de4dot.code {
 				var writerOptions = new ModuleWriterOptions(module, writerListener);
 				writerOptions.MetaDataOptions.Flags |= mdFlags;
 				writerOptions.Logger = Logger.Instance;
+                if(Logger.Instance.ForcePDBGeneration)
+                {
+                    writerOptions.WritePdb = true;
+                    module.CreatePdbState();
+                }
 				module.Write(newFilename, writerOptions);
 			}
 			else {
@@ -64,7 +69,12 @@ namespace de4dot.code {
 				writerOptions.Logger = Logger.Instance;
 				writerOptions.KeepExtraPEData = true;
 				writerOptions.KeepWin32Resources = true;
-				module.NativeWrite(newFilename, writerOptions);
+                if (Logger.Instance.ForcePDBGeneration)
+                {
+                    writerOptions.WritePdb = true;
+                    module.CreatePdbState();
+                }
+                module.NativeWrite(newFilename, writerOptions);
 			}
 		}
 

--- a/de4dot.code/Logger.cs
+++ b/de4dot.code/Logger.cs
@@ -32,6 +32,7 @@ namespace de4dot.code {
 		Dictionary<string, bool> ignoredMessages = new Dictionary<string, bool>(StringComparer.Ordinal);
 		int numIgnoredMessages;
 		bool canIgnoreMessages;
+        bool forcePDBGeneration = false;
 
 		public int IndentLevel {
 			get { return indentLevel; }
@@ -56,6 +57,12 @@ namespace de4dot.code {
 		public int NumIgnoredMessages {
 			get { return numIgnoredMessages; }
 		}
+
+        public bool ForcePDBGeneration
+        {
+            get { return forcePDBGeneration; }
+            set { forcePDBGeneration = value; }
+        }
 
 		public Logger()
 			: this(2, true) {

--- a/de4dot.cui/CommandLineParser.cs
+++ b/de4dot.cui/CommandLineParser.cs
@@ -238,7 +238,12 @@ namespace de4dot.cui {
 				Logger.Instance.MaxLoggerEvent = LoggerEvent.VeryVerbose;
 				Logger.Instance.CanIgnoreMessages = false;
 			}));
-			miscOptions.Add(new NoArgOption("h", "help", "Show this help message", () => {
+            miscOptions.Add(new NoArgOption("fpdb", null, "Force PDB file generation for output", () =>
+            {
+                Logger.Instance.ForcePDBGeneration = true;
+            }));
+            miscOptions.Add(new NoArgOption("h", "help", "Show this help message", () =>
+            {
 				Usage();
 				Exit(0);
 			}));


### PR DESCRIPTION
This pull request adds the following option:

```
-fpdb    Force PDB file generation for output
```
  
This generates the cleaned assembly with a debug symbol information file (.pdb),
thus setting the DEBUG DIRECTORY in the PE header of the assembly correctly.

The .pdb file itself is worthless because it doesn't relate to any source code,
but with the correct debug directory entry in the assembly header, tools like
[DotPeek](https://www.jetbrains.com/decompiler/) can generate a .pdb file for decompiled source. Otherwise, these tools
would not allow generating .pdb files and instead show this error:

> Pdb has not been generated because assembly does not contain debug directory

-- See also: https://youtrack.jetbrains.com/issue/DOTP-6889

**Technical Details**
> When you load a module into the process address space, the debugger uses two
pieces of information to find the matching PDB file. The first is obviously the
name of the file. If you load ZZZ.DLL, the debugger looks for ZZZ.PDB. The
extremely important part is how the debugger knows this is the exact matching
PDB file for this binary. That’s done through a GUID that’s embedded in both the
PDB file and the binary. If the GUID does not match, you certainly won’t debug
the module at the source code level.

-- Quote from: http://www.wintellect.com/devcenter/jrobbins/pdb-files-what-every-developer-must-know
  
Author of original modification: *Ainz Ooal Gown*
- Original patch: https://github.com/earnol/de4dot/commit/24c6e696fb9251f7d048ac33c88c710013a649d6
- Explanation from Ainz: https://stackoverflow.com/a/33332731/785111
