### PR TITLE
Added option --dont-rename-public to only rename everything non-public

### DIFF
--- a/de4dot.cui/CommandLineParser.cs
+++ b/de4dot.cui/CommandLineParser.cs
@@ -123,6 +123,10 @@ namespace de4dot.cui {
 				filesOptions.RenameSymbols = false;
 				filesOptions.RenamerFlags = 0;
 			}));
+            miscOptions.Add(new NoArgOption(null, "dont-rename-public", "Don't rename public classes, methods, etc.", () =>
+            {
+                filesOptions.RenamerFlags |= RenamerFlags.DontRenamePublic;
+            }));
 			miscOptions.Add(new OneArgOption(null, "keep-names", "Don't rename n(amespaces), t(ypes), p(rops), e(vents), f(ields), m(ethods), a(rgs), g(enericparams), d(elegate fields). Can be combined, eg. efm", "flags", (val) => {
 				foreach (var c in val) {
 					switch (c) {


### PR DESCRIPTION
This pull request adds the following option:

```
--dont-rename-public    Do not rename public types, methods, fields, etc.
```

Leaving other options at default, only non-public types and members are renamed. This means that the resulting assembly can still be referenced safely from other referencing assemblies, while obfuscated non-public names are still renamed.

This option is useful, because renaming *all* types and members that match a regex pattern can cause false positives where a public type matches the regex but was not actually obfuscated, for example in Unity's Assembly-CSharp.dll the `public class FPS`. When this gets renamed, it breaks the dll's compatibility with the software referencing this type by name.

Generally, only non-public types are safe to rename (reflection access excluded), which is why most obfuscaters also only obfuscate non-public types.
