### PR TITLE
Support for some DNR >=4.8 versions

### DIFF
--- a/de4dot.code/deobfuscators/dotNET_Reactor/v4/EncryptedResource.cs
+++ b/de4dot.code/deobfuscators/dotNET_Reactor/v4/EncryptedResource.cs
@@ -208,10 +208,8 @@ namespace de4dot.code.deobfuscators.dotNET_Reactor.v4 {
 				requiredTypes.AddRange(additionalTypes);
 				if (!localTypes.All(requiredTypes))
 					return false;
-				if (localTypes.Exists("System.UInt32")) // DNR >=4.8
-					return false;
 				if (DotNetUtils.GetMethod(method.DeclaringType, "System.Security.Cryptography.SymmetricAlgorithm", "()") != null)
-					if (localTypes.Exists("System.UInt64"))
+					if (localTypes.Exists("System.UInt64") || localTypes.Exists("System.UInt32"))
 						return false;
 
 				if (!localTypes.Exists("System.Security.Cryptography.RijndaelManaged") &&

--- a/de4dot.code/deobfuscators/dotNET_Reactor/v4/EncryptedResource.cs
+++ b/de4dot.code/deobfuscators/dotNET_Reactor/v4/EncryptedResource.cs
@@ -189,7 +189,7 @@ namespace de4dot.code.deobfuscators.dotNET_Reactor.v4 {
 			readonly byte[] key, iv;
 
 			public DnrDecrypterType DecrypterType {
-				get { return DnrDecrypterType.V1; } 
+				get { return DnrDecrypterType.V1; }
 			}
 
 			public DecrypterV1(byte[] iv, byte[] key) {

--- a/de4dot.code/deobfuscators/dotNET_Reactor/v4/EncryptedResource.cs
+++ b/de4dot.code/deobfuscators/dotNET_Reactor/v4/EncryptedResource.cs
@@ -136,7 +136,6 @@ namespace de4dot.code.deobfuscators.dotNET_Reactor.v4 {
 						iv[i * 2 + 1] = publicKeyToken.Data[i];
 				}
 			}
-
 			var decrypterType = GetDecrypterType(resourceDecrypterMethod, new string[0]);
 			switch (decrypterType) {
 			case DnrDecrypterType.V1: decrypter = new DecrypterV1(iv, key); break;
@@ -209,7 +208,7 @@ namespace de4dot.code.deobfuscators.dotNET_Reactor.v4 {
 				if (!localTypes.All(requiredTypes))
 					return false;
 				if (DotNetUtils.GetMethod(method.DeclaringType, "System.Security.Cryptography.SymmetricAlgorithm", "()") != null)
-					if (localTypes.Exists("System.UInt64") || localTypes.Exists("System.UInt32"))
+					if (localTypes.Exists("System.UInt64") || localTypes.Exists("System.UInt32") && !localTypes.Exists("System.Reflection.Assembly"))
 						return false;
 
 				if (!localTypes.Exists("System.Security.Cryptography.RijndaelManaged") &&

--- a/de4dot.code/deobfuscators/dotNET_Reactor/v4/EncryptedResource.cs
+++ b/de4dot.code/deobfuscators/dotNET_Reactor/v4/EncryptedResource.cs
@@ -188,9 +188,7 @@ namespace de4dot.code.deobfuscators.dotNET_Reactor.v4 {
 		class DecrypterV1 : IDecrypter {
 			readonly byte[] key, iv;
 
-			public DnrDecrypterType DecrypterType {
-				get { return DnrDecrypterType.V1; }
-			}
+			public DnrDecrypterType DecrypterType => DnrDecrypterType.V1;
 
 			public DecrypterV1(byte[] iv, byte[] key) {
 				this.iv = iv;
@@ -208,7 +206,8 @@ namespace de4dot.code.deobfuscators.dotNET_Reactor.v4 {
 				requiredTypes.AddRange(additionalTypes);
 				if (!localTypes.All(requiredTypes))
 					return false;
-
+				if (localTypes.Exists("System.UInt32")) // DNR >=4.8
+					return false;
 				if (DotNetUtils.GetMethod(method.DeclaringType, "System.Security.Cryptography.SymmetricAlgorithm", "()") != null)
 					if (localTypes.Exists("System.UInt64"))
 						return false;

--- a/de4dot.code/deobfuscators/dotNET_Reactor/v4/EncryptedResource.cs
+++ b/de4dot.code/deobfuscators/dotNET_Reactor/v4/EncryptedResource.cs
@@ -188,7 +188,9 @@ namespace de4dot.code.deobfuscators.dotNET_Reactor.v4 {
 		class DecrypterV1 : IDecrypter {
 			readonly byte[] key, iv;
 
-			public DnrDecrypterType DecrypterType => DnrDecrypterType.V1;
+			public DnrDecrypterType DecrypterType {
+				get { return DnrDecrypterType.V1; } 
+			}
 
 			public DecrypterV1(byte[] iv, byte[] key) {
 				this.iv = iv;

--- a/de4dot.code/deobfuscators/dotNET_Reactor/v4/ProxyCallFixer.cs
+++ b/de4dot.code/deobfuscators/dotNET_Reactor/v4/ProxyCallFixer.cs
@@ -91,8 +91,7 @@ namespace de4dot.code.deobfuscators.dotNET_Reactor.v4 {
 				var call = instrs[i + 1];
 				if (call.OpCode.Code != Code.Call)
 					continue;
-				var calledMethod = call.Operand as MethodDef;
-				if (calledMethod == null || !IsDelegateCreatorMethod(calledMethod))
+				if (!(call.Operand is MethodDef calledMethod) || !IsDelegateCreatorMethod(calledMethod))
 					continue;
 
 				return module.ResolveToken(0x02000000 + ldci4.GetLdcI4Value()) as TypeDef;

--- a/de4dot.code/deobfuscators/dotNET_Reactor/v4/ProxyCallFixer.cs
+++ b/de4dot.code/deobfuscators/dotNET_Reactor/v4/ProxyCallFixer.cs
@@ -91,7 +91,8 @@ namespace de4dot.code.deobfuscators.dotNET_Reactor.v4 {
 				var call = instrs[i + 1];
 				if (call.OpCode.Code != Code.Call)
 					continue;
-				if (!(call.Operand is MethodDef calledMethod) || !IsDelegateCreatorMethod(calledMethod))
+				var calledMethod = call.Operand as MethodDef;
+				if (calledMethod == null || !IsDelegateCreatorMethod(calledMethod))
 					continue;
 
 				return module.ResolveToken(0x02000000 + ldci4.GetLdcI4Value()) as TypeDef;


### PR DESCRIPTION
I've encountered some DotNetReactor versions >= 4.8 (I could not determine the actual version) that de4dot was unable to decrypt due to wrong detection of the Decrypter type. I've added a (sorry, very simple) fix for this. De4dot is now able to decrypt these files as well.