### PR TITLE
[Issue] [Reactor] Try to initialize static string decryption even when using `--strtyp delegate`

### DIFF
--- a/de4dot.code/deobfuscators/dotNET_Reactor/v4/StringDecrypter.cs
+++ b/de4dot.code/deobfuscators/dotNET_Reactor/v4/StringDecrypter.cs
@@ -147,7 +147,7 @@ namespace de4dot.code.deobfuscators.dotNET_Reactor.v4 {
 			if (!encryptedResource.FoundResource)
 				return;
 			Logger.v("Adding string decrypter. Resource: {0}", Utils.ToCsharpString(encryptedResource.Resource.Name));
-			decryptedData = encryptedResource.Decrypt();
+			decryptedData = encryptedResource.Decrypt(); //BUG: throw Error even when using `--strtyp delegate`
 		}
 
 		void FindKeyIv(MethodDef method, out byte[] key, out byte[] iv) {


### PR DESCRIPTION
This is actually an issue report. Please forgive me - at least I'm not going to ask a question...

I have got errors when using de4dot on an assembly obfuscated by reactor v4 (or v5?). After debugging, I found it threw an exception at [EncryptedResource.CalculateMagic(uint)](https://github.com/0xd4d/de4dot/blob/82c24c9280a4495606979d2227eb7461ebd12df1/de4dot.code/deobfuscators/dotNET_Reactor/v4/EncryptedResource.cs#L407) at [StringDecrypter.Initialize()](https://github.com/0xd4d/de4dot/blob/82c24c9280a4495606979d2227eb7461ebd12df1/de4dot.code/deobfuscators/dotNET_Reactor/v4/StringDecrypter.cs#L140).

So it seems that they improved the encryption. But that doesn't matter because we can still try `--strtyp delegate`. Here comes the issue: When using `--strtyp delegate`, [StringDecrypter](https://github.com/0xd4d/de4dot/blob/82c24c9280a4495606979d2227eb7461ebd12df1/de4dot.code/deobfuscators/dotNET_Reactor/v4/StringDecrypter.cs#L150) still calls `encryptedResource.Decrypt();` which throws the exception. As a result, the application just exits.

To overcome this, I have to comment that line in StringDecrypter (or introduce some vars and skip that line). Then I can just use `--strtyp delegate` and everything works without error.

So my suggestion is if `StringDecrypter.Decrypt` won't be used in Delegate mode, maybe it would be better to skip static string decryption initialization when the user specified to use dynamic ways? Since I don't know how you'd like to handle it, I just submit an issue report here.