### PR TITLE
CryptoObfuscator: Fix an issue on GetProxyCreateMethod

### DIFF
--- a/de4dot.code/deobfuscators/CryptoObfuscator/AntiDebugger.cs
+++ b/de4dot.code/deobfuscators/CryptoObfuscator/AntiDebugger.cs
@@ -66,6 +66,7 @@ namespace de4dot.code.deobfuscators.CryptoObfuscator {
 					!ContainsString(method, "run with") &&
 					!ContainsString(method, "started under") &&
 					!ContainsString(method, "{0} detected") &&
+					!ContainsString(method, "{0} was found - this software cannot be executed") &&
 					!ContainsString(method, "{0} found"))
 					continue;
 

--- a/de4dot.code/deobfuscators/CryptoObfuscator/ProxyCallFixer.cs
+++ b/de4dot.code/deobfuscators/CryptoObfuscator/ProxyCallFixer.cs
@@ -109,7 +109,7 @@ namespace de4dot.code.deobfuscators.CryptoObfuscator {
 		MethodDef GetProxyCreateMethod(TypeDef type) {
 			if (DotNetUtils.FindFieldType(type, "System.ModuleHandle", true) == null)
 				return null;
-			if (type.Fields.Count < 1 || type.Fields.Count > 20)
+			if (type.Fields.Count < 1 || type.Fields.Count > 22)
 				return null;
 
 			MethodDef createMethod = null;

--- a/de4dot.code/deobfuscators/CryptoObfuscator/ResourceDecrypter.cs
+++ b/de4dot.code/deobfuscators/CryptoObfuscator/ResourceDecrypter.cs
@@ -313,6 +313,8 @@ namespace de4dot.code.deobfuscators.CryptoObfuscator {
 					yield return method;
 				else if (DotNetUtils.IsMethod(method, "System.Byte[]", "(System.Char,System.IO.Stream)"))
 					yield return method;
+				else if (DotNetUtils.IsMethod(method, "System.Byte[]", "(System.Int64,System.Object)"))
+					yield return method;
 			}
 		}
 


### PR DESCRIPTION
I found this patch on tuts4you from user ivancitooz, which never make a pull request. After reverse engineering (simple diff doesn't work) on released source, I found this simple patch.
I have an exe which is detected as "Crypto Obfuscator For .Net v5.X -> LogicNP Software" from DNiD and "Crypto Obfuscator" from de4dot, I tried some commits, latest and some old, but none deobuscate correctly the exe. I can't exec and delegate methods are not removed.
With this patch the delegate method are removed and the exe works, I can run it. I don't know if this change make issue on other versions of "Crypto Obfuscator". Have you a regression test?

Thank you for your work, de4dot and dnSpy, are very great tools for me.
