### PR TITLE
Fix ForwardScanOrder for TryHandlerBlock

### DIFF
--- a/de4dot.blocks/ForwardScanOrder.cs
+++ b/de4dot.blocks/ForwardScanOrder.cs
@@ -19,6 +19,7 @@
 
 using System;
 using System.Collections.Generic;
+using dnlib.DotNet.Emit;
 
 namespace de4dot.blocks {
 	// This class makes sure that each block that is entered with a non-empty stack has at
@@ -67,7 +68,12 @@ namespace de4dot.blocks {
 		}
 
 		void CreateBlockInfos() {
-			int firstBlockStackStart = scopeBlock is TryHandlerBlock ? 1 : 0;
+			int firstBlockStackStart = 0;
+			if ((scopeBlock is HandlerBlock || scopeBlock is FilterHandlerBlock) &&
+				scopeBlock.Parent is TryHandlerBlock tryHandlerBlock &&
+				(tryHandlerBlock.HandlerType == ExceptionHandlerType.Catch || tryHandlerBlock.HandlerType == ExceptionHandlerType.Filter)) {
+				firstBlockStackStart = 1;
+			}
 			foreach (var bb in GetStartBlocks()) {
 				int stackStart = ReferenceEquals(bb, sorted[0]) ? firstBlockStackStart : 0;
 				ScanBaseBlock(bb, stackStart);


### PR DESCRIPTION
It can be tested by run de4dot with an assembly with the below code
```cs
        string M(string arg1)
        {
            string text2 = "";
            try
            {
                throw null;
            }
            catch (Exception ex) when (ex is NullReferenceException nre && nre.InnerException  == null)//filter block is not required
            {
                while(true)
                {
                    text2 = a + ((arg1 != null || arg1 != null) ? arg1 : "null");
                    try
                    {
                        if (!string.IsNullOrEmpty(text2))
                            throw null;
                    }
                    catch
                    {
                        break;
                    }
                }
            }
            finally//finally block is not required
            {
                while(true)
                {
                    text2 = a + ((arg1 != null || arg1 != null) ? arg1 : "null");
                    try
                    {
                        if (!string.IsNullOrEmpty(text2))
                            throw null;
                    }
                    catch
                    {
                        break;
                    }
                }
            }
            return text2;
        }
```

dnlib/de4dot(when save): `Error calculating max stack value.`
ILSpy: `Incompatible stack heights: 0 vs 1` and `Stack underflow`
PEVerify: `Stack height at all points must be determinable in a single forward scan of IL.`
